### PR TITLE
truncate longer logs preventing 400 errors

### DIFF
--- a/src/main/java/api/DislogClient.kt
+++ b/src/main/java/api/DislogClient.kt
@@ -88,7 +88,20 @@ class DislogClient private constructor(builder: DislogClient.Builder){
             }
             body += "```"
         }
-        return "$body\n_ _"
+
+        var chunkedBody = body.chunked(1950)[0]
+
+        // TODO: Allow for truncation in other messages
+        // TODO: Allow for enable/disable mdc and mdc in another message
+        if (chunkedBody.length >= 1950) {
+            // If odd number of ``` then close it off
+            if ((chunkedBody.count{"```".contains(it)} % 2) == 1) {
+                chunkedBody += "```"
+            }
+            chunkedBody += "\n**Truncated due to length**"
+        }
+
+        return "$chunkedBody\n_ _"
     }
 
     private fun getTimestamp() : String {


### PR DESCRIPTION
When attempting to send bodies over 2k chars discord api returns a 400.

Instead of doing that we should truncate the logs so they dont break that. 

Extended goal is just send them in multiple logs